### PR TITLE
Add support for foreground platforms.

### DIFF
--- a/media/world.ldtk
+++ b/media/world.ldtk
@@ -10,7 +10,7 @@
 	},
 	"jsonVersion": "1.1.3",
 	"appBuildId": 458364,
-	"nextUid": 30,
+	"nextUid": 31,
 	"identifierStyle": "Capitalize",
 	"worldLayout": "Free",
 	"worldGridWidth": 256,
@@ -547,6 +547,35 @@
 					"allowedRefs": "OnlySame",
 					"allowedRefTags": [],
 					"tilesetUid": null
+				},
+				{
+					"identifier": "disable_collider",
+					"__type": "Bool",
+					"uid": 30,
+					"type": "F_Bool",
+					"isArray": false,
+					"canBeNull": false,
+					"arrayMinLength": null,
+					"arrayMaxLength": null,
+					"editorDisplayMode": "Hidden",
+					"editorDisplayPos": "Above",
+					"editorAlwaysShow": false,
+					"editorCutLongValues": true,
+					"editorTextSuffix": null,
+					"editorTextPrefix": null,
+					"useForSmartColor": false,
+					"min": null,
+					"max": null,
+					"regex": null,
+					"acceptFileTypes": null,
+					"defaultOverride": null,
+					"textLanguageMode": null,
+					"symmetricalRef": false,
+					"autoChainRef": true,
+					"allowOutOfLevelRef": true,
+					"allowedRefs": "OnlySame",
+					"allowedRefTags": [],
+					"tilesetUid": null
 				}
 			]
 		},
@@ -876,7 +905,7 @@
 								"entityIid": "4dfc5050-2a00-11ed-83b7-531bb8b7d5e6",
 								"layerIid": "c9615070-2a00-11ed-a23e-7d50545582fa",
 								"levelIid": "a35f3440-2a00-11ed-927c-178e5e51dd51",
-								"worldIid": "7138c680-5110-11ed-b01d-3b6ed695f0fe"
+								"worldIid": "f9f0d630-7820-11ed-b13d-1761ee6ee599"
 							}, "__type": "EntityRef", "__tile": null, "defUid": 25, "realEditorValues": [{
 								"id": "V_String",
 								"params": ["4dfc5050-2a00-11ed-83b7-531bb8b7d5e6"]
@@ -910,7 +939,8 @@
 								{ "__identifier": "renderer", "__value": "EntityTiles", "__type": "LocalEnum.Renderer", "__tile": null, "defUid": 28, "realEditorValues": [{
 									"id": "V_String",
 									"params": ["EntityTiles"]
-								}] }
+								}] },
+								{ "__identifier": "disable_collider", "__value": false, "__type": "Bool", "__tile": null, "defUid": 30, "realEditorValues": [] }
 							]
 						},
 						{
@@ -926,6 +956,35 @@
 							"defUid": 29,
 							"px": [128,208],
 							"fieldInstances": []
+						},
+						{
+							"__identifier": "MovingPlatform",
+							"__grid": [11,5],
+							"__pivot": [0,0],
+							"__tags": [],
+							"__tile": null,
+							"__smartColor": "#EFE606",
+							"iid": "05238160-7820-11ed-b13d-a384b5f0dd62",
+							"width": 16,
+							"height": 48,
+							"defUid": 15,
+							"px": [176,80],
+							"fieldInstances": [
+								{ "__identifier": "endpoint", "__value": { "cx": 11, "cy": 5 }, "__type": "Point", "__tile": null, "defUid": 16, "realEditorValues": [{
+									"id": "V_String",
+									"params": ["11,5"]
+								}] },
+								{ "__identifier": "ping_pong", "__value": false, "__type": "Bool", "__tile": null, "defUid": 24, "realEditorValues": [] },
+								{ "__identifier": "stop_when_blocked", "__value": false, "__type": "Bool", "__tile": null, "defUid": 26, "realEditorValues": [] },
+								{ "__identifier": "renderer", "__value": "EntityTiles", "__type": "LocalEnum.Renderer", "__tile": null, "defUid": 28, "realEditorValues": [{
+									"id": "V_String",
+									"params": ["EntityTiles"]
+								}] },
+								{ "__identifier": "disable_collider", "__value": true, "__type": "Bool", "__tile": null, "defUid": 30, "realEditorValues": [{
+									"id": "V_Bool",
+									"params": [ true ]
+								}] }
+							]
 						}
 					]
 				},
@@ -1201,8 +1260,11 @@
 						{ "px": [384,32], "src": [0,0], "f": 0, "t": 0, "d": [116] },
 						{ "px": [384,48], "src": [0,0], "f": 0, "t": 0, "d": [162] },
 						{ "px": [384,64], "src": [0,0], "f": 0, "t": 0, "d": [208] },
+						{ "px": [176,80], "src": [0,0], "f": 0, "t": 0, "d": [241] },
 						{ "px": [384,80], "src": [0,0], "f": 0, "t": 0, "d": [254] },
-						{ "px": [384,96], "src": [0,0], "f": 0, "t": 0, "d": [300] }
+						{ "px": [176,96], "src": [0,0], "f": 0, "t": 0, "d": [287] },
+						{ "px": [384,96], "src": [0,0], "f": 0, "t": 0, "d": [300] },
+						{ "px": [176,112], "src": [0,0], "f": 0, "t": 0, "d": [333] }
 					],
 					"entityInstances": []
 				},
@@ -2041,7 +2103,8 @@
 								{ "__identifier": "renderer", "__value": "EntityTiles", "__type": "LocalEnum.Renderer", "__tile": null, "defUid": 28, "realEditorValues": [{
 									"id": "V_String",
 									"params": ["EntityTiles"]
-								}] }
+								}] },
+								{ "__identifier": "disable_collider", "__value": false, "__type": "Bool", "__tile": null, "defUid": 30, "realEditorValues": [] }
 							]
 						},
 						{

--- a/src/level.rs
+++ b/src/level.rs
@@ -118,6 +118,7 @@ pub struct MovingPlatformArgs {
     pub end_point: Vec2,
     pub ping_pong: bool,
     pub stop_when_blocked: bool,
+    pub disable_collider: bool,
     pub renderer_type: RendererType,
 }
 
@@ -188,6 +189,7 @@ impl Level {
                             end_point: field_into::<Vec2>(&mut fields, "endpoint")? * grid_size,
                             ping_pong: field_into(&mut fields, "ping_pong")?,
                             stop_when_blocked: field_into(&mut fields, "stop_when_blocked")?,
+                            disable_collider: field_into(&mut fields, "disable_collider")?,
                             renderer_type: field_into(&mut fields, "renderer")?,
                         }),
                         "Crate" => EntityKind::Crate,

--- a/src/moving_platform.rs
+++ b/src/moving_platform.rs
@@ -9,6 +9,7 @@ use crate::{
     physics::PhysicsComponent,
     route::RouteComponent,
     sprite_component::{Renderer, SpriteComponent},
+    z_index::{ZIndexComponent, FOREGROUND_Z_INDEX},
 };
 
 pub fn create_moving_platform(start_rect: Rect, args: &MovingPlatformArgs) -> Entity {
@@ -30,14 +31,23 @@ pub fn create_moving_platform(start_rect: Rect, args: &MovingPlatformArgs) -> En
             defies_gravity: true,
             ..Default::default()
         },
-        dynamic_collider: Some(DynamicColliderComponent::new(RelativeCollider {
-            rect: relative_bbox,
-            collision_flags: CollisionFlags::ENVIRONMENT,
-            enable_top: true,
-            enable_bottom: true,
-            enable_left: true,
-            enable_right: true,
-        })),
+        z_index: if args.disable_collider {
+            ZIndexComponent::new(FOREGROUND_Z_INDEX)
+        } else {
+            Default::default()
+        },
+        dynamic_collider: if args.disable_collider {
+            None
+        } else {
+            Some(DynamicColliderComponent::new(RelativeCollider {
+                rect: relative_bbox,
+                collision_flags: CollisionFlags::ENVIRONMENT,
+                enable_top: true,
+                enable_bottom: true,
+                enable_left: true,
+                enable_right: true,
+            }))
+        },
         route: Some(RouteComponent {
             start_point,
             end_point: args.end_point,

--- a/src/player.rs
+++ b/src/player.rs
@@ -19,7 +19,7 @@ use crate::{
     sprite_renderer::SpriteRenderer,
     time::GameTime,
     world::World,
-    z_index::ZIndexComponent,
+    z_index::{ZIndexComponent, PLAYER_Z_INDEX},
 };
 
 #[derive(Default, Copy, Clone)]
@@ -40,7 +40,7 @@ pub fn create_player(start_rect: Rect, name_for_debugging: &'static str) -> Enti
             ..Default::default()
         }
         .at_bottom_left(&start_rect),
-        z_index: ZIndexComponent::new(500),
+        z_index: ZIndexComponent::new(PLAYER_Z_INDEX),
         player: Some(PlayerComponent {
             has_spear: true,
             ..Default::default()

--- a/src/z_index.rs
+++ b/src/z_index.rs
@@ -2,6 +2,10 @@ use std::cell::RefCell;
 
 use crate::{entity::EntityMap, level::Level};
 
+pub const PLAYER_Z_INDEX: i32 = 500;
+
+pub const FOREGROUND_Z_INDEX: i32 = 550;
+
 #[derive(Default, Clone, Copy)]
 pub struct ZIndexComponent {
     value: i32,


### PR DESCRIPTION
This fixes #51.

## To do

- [ ] This adds a `disable_collider` flag to `MovingPlatform`, but I kinda feel like the entity should just be called `Platform` and the endpoint made optional?  Either that or we just make a separate entity entirely, but that feels too specialized.
- [ ] Consider adding an `is_foreground` property to `MovingPlatform` too, instead of forcing everything with a disabled collider to be in the foreground (which feels non-obvious).  Then again, this could just complicate level development... 🤔 (Alternatively, make z-index enum type?)